### PR TITLE
Allow new items with db-generated ids in ElementCollectionField

### DIFF
--- a/src/main/java/org/vaadin/viritin/FilterableListContainer.java
+++ b/src/main/java/org/vaadin/viritin/FilterableListContainer.java
@@ -66,11 +66,9 @@ public class FilterableListContainer<T> extends ListContainer<T> implements
     private void applyFilters() {
         filteredItems = new ArrayList<T>();
         if (isFiltered()) {
-            boolean appliedFilter = false;
             for (T itemId : super.getBackingList()) {
                 if (passesFilters(itemId)) {
                     filteredItems.add(itemId);
-                    appliedFilter = true;
                 }
             }
         }

--- a/src/main/java/org/vaadin/viritin/components/DisclosurePanel.java
+++ b/src/main/java/org/vaadin/viritin/components/DisclosurePanel.java
@@ -16,8 +16,8 @@ public class DisclosurePanel extends VerticalLayout {
     private FontIcon closedIcon = FontAwesome.PLUS_CIRCLE;
     private FontIcon openIcon = FontAwesome.MINUS_CIRCLE;
 
-    private MButton toggle = new MButton(closedIcon);
-    private MVerticalLayout contentWrapper = new MVerticalLayout();
+    private final MButton toggle = new MButton(closedIcon);
+    private final MVerticalLayout contentWrapper = new MVerticalLayout();
 
     public DisclosurePanel() {
         toggle.setStyleName(ValoTheme.BUTTON_BORDERLESS);

--- a/src/main/java/org/vaadin/viritin/fields/AbstractElementCollection.java
+++ b/src/main/java/org/vaadin/viritin/fields/AbstractElementCollection.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -284,7 +285,7 @@ public abstract class AbstractElementCollection<ET> extends CustomField<Collecti
         }
     }
 
-    private final Map<ET, EditorStuff> pojoToEditor = new HashMap<ET, EditorStuff>();
+    private final Map<ET, EditorStuff> pojoToEditor = new IdentityHashMap<ET, EditorStuff>();
 
     protected final MBeanFieldGroup<ET> getFieldGroupFor(ET pojo) {
         EditorStuff es = pojoToEditor.get(pojo);

--- a/src/main/java/org/vaadin/viritin/fields/AbstractElementCollection.java
+++ b/src/main/java/org/vaadin/viritin/fields/AbstractElementCollection.java
@@ -302,8 +302,7 @@ public abstract class AbstractElementCollection<ET> extends CustomField<Collecti
     protected final Component getComponentFor(ET pojo, String property) {
         EditorStuff editorsstuff = pojoToEditor.get(pojo);
         if (editorsstuff == null) {
-            Object o = null;
-            o = createEditorInstance();
+            Object o = createEditorInstance();
             MBeanFieldGroup bfg = BeanBinder.bind(pojo, o).withEagerValidation(
                     fieldGroupListener);
             editorsstuff = new EditorStuff(bfg, o);

--- a/src/main/java/org/vaadin/viritin/fields/AbstractNumberField.java
+++ b/src/main/java/org/vaadin/viritin/fields/AbstractNumberField.java
@@ -34,7 +34,11 @@ public abstract class AbstractNumberField<T> extends CustomField<T> implements
         @Override
         public void valueChange(Property.ValueChangeEvent event) {
             Object value = event.getProperty().getValue();
-            userInputToValue(String.valueOf(value));
+            if(value != null) {
+                userInputToValue(String.valueOf(value));
+            }else {
+                setValue(null);
+            }
         }
     };
 

--- a/src/main/java/org/vaadin/viritin/fields/CheckBoxGroup.java
+++ b/src/main/java/org/vaadin/viritin/fields/CheckBoxGroup.java
@@ -119,10 +119,6 @@ public class CheckBoxGroup<ET> extends CustomField<Collection> {
         return c;
     }
 
-    private boolean isContainerInitialized() {
-        return optionGroup.size() != 0;
-    }
-
     @Override
     protected Component initContent() {
         return optionGroup;

--- a/src/main/java/org/vaadin/viritin/fields/ElementCollectionField.java
+++ b/src/main/java/org/vaadin/viritin/fields/ElementCollectionField.java
@@ -117,7 +117,7 @@ public class ElementCollectionField<ET> extends AbstractElementCollection<ET> {
 
     @Override
     public void removeInternalElement(ET v) {
-        int index = items.indexOf(v);
+        int index = itemsIdentityIndexOf(v);
         items.remove(index);
         int row = index + 1;
         layout.removeRow(row);
@@ -130,7 +130,7 @@ public class ElementCollectionField<ET> extends AbstractElementCollection<ET> {
 
     @Override
     public void setPersisted(ET v, boolean persisted) {
-        int row = items.indexOf(v) + 1;
+        int row = itemsIdentityIndexOf(v) + 1;
         if (isAllowRemovingItems()) {
             Button c = (Button) layout.getComponent(getVisibleProperties().
                     size(),
@@ -152,6 +152,15 @@ public class ElementCollectionField<ET> extends AbstractElementCollection<ET> {
             }
             c.setEnabled(persisted);
         }
+    }
+
+    private int itemsIdentityIndexOf(Object o) {
+        for (int index = 0; index < items.size(); index++) {
+            if (items.get(index) == o) {
+                return index;
+            }
+        }
+        return -1;
     }
 
     private void ensureInited() {

--- a/src/main/java/org/vaadin/viritin/fields/IntegerField.java
+++ b/src/main/java/org/vaadin/viritin/fields/IntegerField.java
@@ -1,5 +1,7 @@
 package org.vaadin.viritin.fields;
 
+import org.apache.commons.lang3.StringUtils;
+
 /**
  * An field to edit integers.
  *
@@ -22,7 +24,11 @@ public class IntegerField extends AbstractNumberField<Integer> {
 
     @Override
     protected void userInputToValue(String str) {
-        setValue(Integer.parseInt(str));
+        if (StringUtils.isNotBlank(str)) {
+            setValue(Integer.parseInt(str));
+        } else {
+            setValue(null);
+        }
     }
 
     @Override

--- a/src/main/java/org/vaadin/viritin/fields/LazyComboBox.java
+++ b/src/main/java/org/vaadin/viritin/fields/LazyComboBox.java
@@ -9,7 +9,6 @@ import com.vaadin.shared.ui.combobox.FilteringMode;
 import com.vaadin.ui.ComboBox;
 import org.apache.commons.lang3.ObjectUtils;
 import org.vaadin.viritin.LazyList;
-import org.vaadin.viritin.LazyList.CountProvider;
 import org.vaadin.viritin.ListContainer;
 
 import java.util.Collection;

--- a/src/main/java/org/vaadin/viritin/fields/LazyComboBox.java
+++ b/src/main/java/org/vaadin/viritin/fields/LazyComboBox.java
@@ -50,8 +50,6 @@ public class LazyComboBox<T> extends TypedSelect<T> {
         public int size(String filter);
     }
 
-    private CountProvider countProvider;
-
     private LazyList<T> piggybackLazyList;
 
     /**

--- a/src/main/java/org/vaadin/viritin/fields/MCheckBox.java
+++ b/src/main/java/org/vaadin/viritin/fields/MCheckBox.java
@@ -7,6 +7,9 @@ import com.vaadin.ui.CheckBox;
 
 public class MCheckBox extends CheckBox {
 
+    public MCheckBox() {
+    }
+
     public MCheckBox(String caption) {
         super(caption);
     }

--- a/src/main/java/org/vaadin/viritin/fields/SubSetSelector.java
+++ b/src/main/java/org/vaadin/viritin/fields/SubSetSelector.java
@@ -273,7 +273,7 @@ public class SubSetSelector<ET> extends CustomField<Collection> implements Abstr
         table.addItem(entity);
         selected.add(entity);
         if (newInstanceForm != null) {
-            newInstanceForm.closePopup();;
+            newInstanceForm.closePopup();
         }
         // fire value change
         fireValueChange(true);

--- a/src/main/java/org/vaadin/viritin/fields/SubSetSelector.java
+++ b/src/main/java/org/vaadin/viritin/fields/SubSetSelector.java
@@ -13,6 +13,7 @@ import com.vaadin.ui.themes.Reindeer;
 import java.util.Arrays;
 
 import com.vaadin.ui.themes.ValoTheme;
+import java.util.HashSet;
 import org.vaadin.viritin.button.MButton;
 import org.vaadin.viritin.form.AbstractForm;
 import org.vaadin.viritin.layouts.MHorizontalLayout;
@@ -23,7 +24,8 @@ import org.vaadin.viritin.layouts.MVerticalLayout;
  * as "TwinColSelect", but available options are in a combobox for easy picking,
  * and selected entries are displayed in a Table. Should work with virtually any
  * collection type - not just with sets, but same bean can be only once in the
- * collection.
+ * collection. If a null is passed for the field value, it is "converted" into
+ * and empty Set or list List.
  * <p>
  * The component can be configured to create new entities as well on demand,
  * either by hitting enter with ComboBox or with a new entry form, or combined.
@@ -67,8 +69,8 @@ public class SubSetSelector<ET> extends CustomField<Collection> implements Abstr
                     com.vaadin.data.Property.ValueChangeEvent event) {
                 if (event.getProperty().getValue() != null) {
                     Object pojo = event.getProperty().getValue();
-                    cb.setValue(null);
                     cb.getBic().removeItem(pojo);
+                    cb.setValue(null);
                     table.addItem(pojo);
                     selected.add(pojo);
                     // fire value change
@@ -229,11 +231,21 @@ public class SubSetSelector<ET> extends CustomField<Collection> implements Abstr
     @Override
     protected void setInternalValue(Collection newValue) {
         selected = newValue;
+        if(selected == null) {
+            Class<Collection> clazz = getType();
+            if(clazz != null && List.class.isAssignableFrom(clazz)) {
+                selected = new ArrayList();
+            } else {
+                selected = new HashSet();
+            }
+            setValue(selected);
+            return;
+        }
         final ArrayList<ET> arrayList = new ArrayList<>(availableOptions);
         arrayList.removeAll(selected);
         cb.setOptions(arrayList);
         cb.getBic().fireItemSetChange();
-        table.setBeans(selected);
+        table.setBeans(new ArrayList(selected));
         super.setInternalValue(newValue);
     }
 

--- a/src/main/java/org/vaadin/viritin/grid/utils/GridUtils.java
+++ b/src/main/java/org/vaadin/viritin/grid/utils/GridUtils.java
@@ -124,7 +124,7 @@ public class GridUtils {
                         SortOrder soCreated = new SortOrder(propertyId,
                                 direction);
                         sortOrderList.add(soCreated);
-                    };
+                    }
                 }
                 grid.setSortOrder(sortOrderList);
             }

--- a/src/main/java/org/vaadin/viritin/grid/utils/GridUtils.java
+++ b/src/main/java/org/vaadin/viritin/grid/utils/GridUtils.java
@@ -26,7 +26,6 @@ public class GridUtils {
     private final String HIDDEN_SETTINGS_NAME;
     private final String SORT_ORDER_SETTINGS_NAME;
     private final String COLUMNS_ORDER_SETTINGS_NAME;
-    private final List<String> columnsOrder = new ArrayList<String>();
     private final Grid grid;
 
     /**
@@ -68,12 +67,12 @@ public class GridUtils {
 
             @Override
             public void columnReorder(ColumnReorderEvent event) {
-                saveColumnOrder(event);
+                saveColumnOrder();
             }
         });
     }
 
-    private void saveColumnOrder(ColumnReorderEvent e) {
+    private void saveColumnOrder() {
         //Number of columns not more than 1000, hopefully :)
         //This operation don't need to be fast, that's why were recreate the cookie value
         //every time.

--- a/src/main/java/org/vaadin/viritin/layouts/MGridLayout.java
+++ b/src/main/java/org/vaadin/viritin/layouts/MGridLayout.java
@@ -16,6 +16,18 @@ public class MGridLayout extends GridLayout {
         super.setMargin(true);
     }
 
+    public MGridLayout(int columns, int rows) {
+        super(columns, rows);
+        super.setSpacing(true);
+        super.setMargin(true);
+    }
+
+    public MGridLayout(int columns, int rows, Component... children) {
+        super(columns, rows, children);
+        super.setSpacing(true);
+        super.setMargin(true);
+    }
+    
     public MGridLayout(Component... components) {
         this();
         addComponents(components);

--- a/src/main/java/org/vaadin/viritin/util/HtmlElementPropertySetter.java
+++ b/src/main/java/org/vaadin/viritin/util/HtmlElementPropertySetter.java
@@ -1,13 +1,7 @@
 package org.vaadin.viritin.util;
 
-import com.vaadin.annotations.Theme;
 import com.vaadin.server.AbstractJavaScriptExtension;
 import com.vaadin.ui.AbstractComponent;
-import com.vaadin.ui.JavaScript;
-import java.io.IOException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import org.apache.commons.io.IOUtils;
 
 /**
  * A simple extension to set custom properties for the html elements used in

--- a/src/main/java/org/vaadin/viritin/util/VaadinLocale.java
+++ b/src/main/java/org/vaadin/viritin/util/VaadinLocale.java
@@ -54,9 +54,7 @@ public class VaadinLocale {
         }
         this.localeNegotiationStrategey = localeNegotiationStrategey;
 
-        for (Locale locale : supportedLocales) {
-            this.supportedLocales.add(locale);
-        }
+        this.supportedLocales.addAll(Arrays.asList(supportedLocales));
     }
 
     /**

--- a/src/test/java/org/vaadin/viritin/fields/IntegerFieldTest.java
+++ b/src/test/java/org/vaadin/viritin/fields/IntegerFieldTest.java
@@ -1,0 +1,34 @@
+package org.vaadin.viritin.fields;
+
+import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.*;
+import org.junit.*;
+
+public class IntegerFieldTest {
+
+    private IntegerField fieldUnderTest;
+
+    @Before
+    public void setUp() throws Exception {
+        fieldUnderTest = new IntegerField();
+    }
+
+    @Test
+    public void testUserInputToValue_freshField() {
+        assertThat(fieldUnderTest.getValue(), is((Integer) null));
+    }
+
+    @Test
+    public void testUserInputToValue() {
+        fieldUnderTest.userInputToValue("2");
+        assertThat(fieldUnderTest.getValue(), is(2));
+    }
+
+    @Test
+    public void testUserInputToValue_changeValueToNull() {
+        fieldUnderTest.userInputToValue("2");
+        fieldUnderTest.userInputToValue("");
+        assertThat(fieldUnderTest.getValue(), is((Integer) null));
+    }
+
+}

--- a/src/test/java/org/vaadin/viritin/it/SubSetSelectorExample.java
+++ b/src/test/java/org/vaadin/viritin/it/SubSetSelectorExample.java
@@ -2,8 +2,10 @@ package org.vaadin.viritin.it;
 
 import com.vaadin.annotations.Theme;
 import com.vaadin.data.Property;
+import com.vaadin.ui.Button;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.Notification;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -84,10 +86,17 @@ public class SubSetSelectorExample extends AbstractTest {
         sss.setValue(selected);
         
         sss.addValueChangeListener((Property.ValueChangeEvent event) -> {
-            Notification.show("Value now :" + selected.toString());
+            Notification.show("Value now :" + sss.getValue());
         });
+        
+        
+        Button setNull = new Button("setValue(null)");
+        setNull.addClickListener(e->{sss.setValue(null);});
+        
+        Button setList = new Button("setValue(new ArrayList())");
+        setList.addClickListener(e->{sss.setValue(new ArrayList());});
 
-        return new MVerticalLayout(sss);
+        return new MVerticalLayout(sss, setNull, setList);
         
     }
 


### PR DESCRIPTION
Use items identity, because new items with db-generated ids may be equals.
